### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,27 +14,27 @@
     :target: https://coveralls.io/r/DFE/MONK
     :alt: Coveralls Quality
 
-.. image:: https://pypip.in/license/monk_tf/badge.svg
+.. image:: https://img.shields.io/pypi/l/monk_tf.svg
     :target: https://pypi.python.org/pypi/monk_tf
     :alt: License
 
-.. image:: https://pypip.in/download/monk_tf/badge.svg
+.. image:: https://img.shields.io/pypi/dm/monk_tf.svg
     :target: https://pypi.python.org/pypi/monk_tf
     :alt: Downloads
 
-.. image:: https://pypip.in/version/monk_tf/badge.svg
+.. image:: https://img.shields.io/pypi/v/monk_tf.svg
     :target: https://pypi.python.org/pypi/monk_tf
     :alt: Latest Version
 
-.. image:: https://pypip.in/py_versions/monk_tf/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/monk_tf.svg
     :target: https://pypi.python.org/pypi/monk_tf
     :alt: Supported Python Versions
 
-.. image:: https://pypip.in/status/monk_tf/badge.svg
+.. image:: https://img.shields.io/pypi/status/monk_tf.svg
     :target: https://pypi.python.org/pypi/monk_tf
     :alt: Current Devel Status
 
-.. image:: https://pypip.in/format/monk_tf/badge.svg
+.. image:: https://img.shields.io/pypi/format/monk_tf.svg
     :target: https://pypi.python.org/pypi/monk_tf
     :alt: Support Package Format
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tmonk))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tmonk`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.